### PR TITLE
Remove mention of wrap-remotes from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ The noir side of things is just as simple. All you do is declare a remote using 
            {:username "Chris"
             :age 24})
 
-(server/add-middleware wrap-remotes)
-
 (server/start 8080)
 ```
 


### PR DESCRIPTION
The example in README.md still uses the obsolete `wrap-remotes` middleware.
