### PR TITLE
removes old Noir dependencies, replaces defpage with compojure route

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fetch "0.1.0-alpha2"
+(defproject fetch "0.1.0-alpha3"
   :description "A ClojureScript and Noir library to make client-server interaction painless."
-  :dependencies [[clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
                  [noir "1.2.2"]])

--- a/src/noir/fetch/remotes.clj
+++ b/src/noir/fetch/remotes.clj
@@ -1,4 +1,5 @@
 (ns noir.fetch.remotes
+  (:require [clojure.edn :as edn])
   (:use [noir.core :only [defpage]]))
 
 (def remotes (atom {}))
@@ -10,8 +11,7 @@
   (swap! remotes assoc remote func))
 
 (defn safe-read [s]
-  (binding [*read-eval* false]
-    (read-string s)))
+  (edn/read-string s))
 
 (defmacro defremote [remote params & body]
   `(do

--- a/src/noir/fetch/remotes.clj
+++ b/src/noir/fetch/remotes.clj
@@ -1,6 +1,6 @@
 (ns noir.fetch.remotes
-  (:require [clojure.edn :as edn])
-  (:use [noir.core :only [defpage]]))
+  (:require [clojure.edn :as edn]
+            [compojure.core :refer :all]))
 
 (def remotes (atom {}))
 
@@ -30,7 +30,8 @@
   (println "*** fetch/wrap-remotes is no longer needed. Please remove it ***")
   handler)
 
-(defpage [:any "/_fetch"] {:keys [remote params]}
-  (let [params (safe-read params)
-        remote (keyword remote)]
-    (call-remote remote params)))
+(defroutes fetch-routes
+  (ANY "/_fetch" [remote params]
+       (let [params (safe-read params)
+             remote (keyword remote)]
+         (call-remote remote params))))


### PR DESCRIPTION
(Note that this incorporates bvandgrift's pull request: https://github.com/ibdknox/fetch/pull/15)

This is kind of an "exploratory" pull request.  I'm using fetch in a project which is ripping out most of the Noir stuff, but I wanted to keep using fetch.  So spiked out a quick solution by replacing the defpage call with a simple Compojure route.

Of course this also necessitates adding the route to your app's handlers, which means it would probably make sense to add some middleware for this...like say um, wrap-remote...

So, not sure if this is something you want to do or not, but since Noir is deprecated and many folks seem to be moving to lib-noir (I think?).  On the other hand, this would be a pretty big breaking change, so I'm not sure if it makes sense to do this outside of a fork now.

If you want, I'll write some tests for it, flesh out wrap-remote (again) and tweak the instructions in the README.  If not, I'll fork it properly, renaming it to "fetch-sans-noir" or something.

Cheers--DD