### PR TITLE
Remove dependency on goog.net.XhrIo and goog.events

### DIFF
--- a/src/fetch/core.cljs
+++ b/src/fetch/core.cljs
@@ -1,8 +1,8 @@
 (ns fetch.core
-  (:require [goog.net.XhrIo :as xhr]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
+            [clojure.browser.net :as net]
+            [clojure.browser.event :as event]
             [cljs.reader :as reader]
-            [goog.events :as events]
             [goog.Uri.QueryData :as query-data]
             [goog.structs :as structs]))
 
@@ -28,10 +28,10 @@
         (callback data)))))
 
 (defn xhr [route content callback & [opts]]
-  (let [req (new goog.net.XhrIo)
+  (let [req (net/xhr-connection)
         [method uri] (parse-route route)
         data (->data content)
         callback (->callback callback)]
     (when callback
-      (events/listen req goog.net.EventType/COMPLETE #(callback req)))
-    (. req (send uri method data (when opts (clj->js opts))))))
+      (event/listen req :success #(callback req)))
+    (net/transmit req uri method data (when opts (clj->js opts)))))


### PR DESCRIPTION
I'm experimenting with migrating LightTable to latest clojurescript version. 
One of the biggest problem is that fetch uses API changed in Google Closure Library. So it can't find `goog.net.EventType/COMPLETE`

In this PR I tried to make it xhr function more idiomatic and relying on cljs wrappers rather than on closure lib.  